### PR TITLE
Fixes Issue #18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ workflows:
   version: 2.1
   test:
     jobs:
+      - test-3_9
       - test-3_8
       - test-3_7
       - test-3_6
@@ -23,6 +24,7 @@ workflows:
               only:
                 - master
     jobs:
+      - test-3_9
       - test-3_8
       - test-3_7
       - test-3_6
@@ -30,7 +32,7 @@ workflows:
 jobs:
   test-3_8: &test-template
     docker:
-      - image: circleci/python:3.8.5
+      - image: circleci/python:3.8.9
 
     working_directory: ~/repo
 
@@ -82,8 +84,12 @@ jobs:
   test-3_6:
     <<: *test-template
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python:3.6.9
   test-3_7:
     <<: *test-template
     docker:
-      - image: circleci/python:3.7.8
+      - image: circleci/python:3.7.10
+  test-3_9:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.9.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 21.5b1
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v0.3.0
+    rev: v1.10.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==18.9b0]
+        additional_dependencies: [black]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:

--- a/ncbi_cds_from_protein/entrez.py
+++ b/ncbi_cds_from_protein/entrez.py
@@ -314,8 +314,6 @@ def elink_fetch_with_retries(query_id, dbname, linkdbname, maxretries):
     linkdbname      - NCBI target database name for link query
     maxretries      - maximum number of attempts to make
     """
-    import json
-
     logger = logging.getLogger(__name__)
     logger.debug("ELink query: %s", query_id)
 

--- a/ncbi_cds_from_protein/entrez.py
+++ b/ncbi_cds_from_protein/entrez.py
@@ -314,6 +314,8 @@ def elink_fetch_with_retries(query_id, dbname, linkdbname, maxretries):
     linkdbname      - NCBI target database name for link query
     maxretries      - maximum number of attempts to make
     """
+    import json
+
     logger = logging.getLogger(__name__)
     logger.debug("ELink query: %s", query_id)
 
@@ -327,7 +329,7 @@ def elink_fetch_with_retries(query_id, dbname, linkdbname, maxretries):
         except Exception:
             tries += 1
             logger.warning(
-                "ELing query (%s) failed (retry %d)", query_id, tries, exc_info=True
+                "ELink query (%s) failed (retry %d)", query_id, tries, exc_info=True
             )
     raise NCFPMaxretryException("Query ID %s ELink failed" % query_id)
 

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -45,7 +45,6 @@ import pytest
 from unittest.mock import Mock
 
 from Bio import Entrez
-from Bio.Entrez import Parser
 from bioservices import UniProt
 
 from ncbi_cds_from_protein.scripts import ncfp
@@ -127,10 +126,50 @@ def mock_entrez_create_and_keep_cache(monkeypatch):
     responses.side_effect = [
         io.BytesIO(_)
         for _ in (
-            b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult PUBLIC "-//NLM//DTD elink 20101123//EN" "https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  <LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>10835069</Id>\n    </IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      <LinkName>protein_nuccore</LinkName>\n      \n        <Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n        <Link>\n\t\t\t\t<Id>197116381</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  </LinkSet>\n</eLinkResult>\n',
-            b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult PUBLIC "-//NLM//DTD elink 20101123//EN" "https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  <LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>283135214</Id>\n    </IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      <LinkName>protein_nuccore</LinkName>\n      \n        <Link>\n\t\t\t\t<Id>1677498684</Id>\n\t\t\t</Link>\n        <Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  </LinkSet>\n</eLinkResult>\n',
-            b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult PUBLIC "-//NLM//DTD elink 20101123//EN" "https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  <LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>530397002</Id>\n    </IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      <LinkName>protein_nuccore</LinkName>\n      \n        <Link>\n\t\t\t\t<Id>767968522</Id>\n\t\t\t</Link>\n        <Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  </LinkSet>\n</eLinkResult>\n',
-            b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult PUBLIC "-//NLM//DTD elink 20101123//EN" "https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  <LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>283135242</Id>\n    </IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      <LinkName>protein_nuccore</LinkName>\n      \n        <Link>\n\t\t\t\t<Id>1677500256</Id>\n\t\t\t</Link>\n        <Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  </LinkSet>\n</eLinkResult>\n',
+            (
+                b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult '
+                b'PUBLIC "-//NLM//DTD elink 20101123//EN" '
+                b'"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  '
+                b"<LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>10835069</Id>\n    "
+                b"</IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      "
+                b"<LinkName>protein_nuccore</LinkName>\n      \n        "
+                b"<Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n        "
+                b"<Link>\n\t\t\t\t<Id>197116381</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  "
+                b"</LinkSet>\n</eLinkResult>\n"
+            ),
+            (
+                b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult '
+                b'PUBLIC "-//NLM//DTD elink 20101123//EN" '
+                b'"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  '
+                b"<LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>283135214</Id>\n    "
+                b"</IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      "
+                b"<LinkName>protein_nuccore</LinkName>\n      \n        "
+                b"<Link>\n\t\t\t\t<Id>1677498684</Id>\n\t\t\t</Link>\n        "
+                b"<Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  "
+                b"</LinkSet>\n</eLinkResult>\n"
+            ),
+            (
+                b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult '
+                b'PUBLIC "-//NLM//DTD elink 20101123//EN" '
+                b'"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  '
+                b"<LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>530397002</Id>\n    "
+                b"</IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      "
+                b"<LinkName>protein_nuccore</LinkName>\n      \n        "
+                b"<Link>\n\t\t\t\t<Id>767968522</Id>\n\t\t\t</Link>\n        "
+                b"<Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n      \n    </LinkSetDb>\n  "
+                b"</LinkSet>\n</eLinkResult>\n"
+            ),
+            (
+                b'<?xml version="1.0" encoding="UTF-8" ?>\n<!DOCTYPE eLinkResult '
+                b'PUBLIC "-//NLM//DTD elink 20101123//EN" '
+                b'"https://eutils.ncbi.nlm.nih.gov/eutils/dtd/20101123/elink.dtd">\n<eLinkResult>\n\n  '
+                b"<LinkSet>\n    <DbFrom>protein</DbFrom>\n    <IdList>\n      <Id>283135242</Id>\n    "
+                b"</IdList>\n    <LinkSetDb>\n      <DbTo>nuccore</DbTo>\n      "
+                b"<LinkName>protein_nuccore</LinkName>\n      \n        "
+                b"<Link>\n\t\t\t\t<Id>1677500256</Id>\n\t\t\t</Link>\n        "
+                b"<Link>\n\t\t\t\t<Id>568815587</Id>\n\t\t\t</Link>\n      \n    "
+                b"</LinkSetDb>\n  </LinkSet>\n</eLinkResult>\n"
+            ),
         )
     ]
 


### PR DESCRIPTION
Mocks calls to Entrez elink from the `create_and_keep_cache` test. CI tests ran cleanly after the change.

Also updates `pre-commit` config, CircleCI docker images, and adds testing for Python 3.9.

Fixes #18 