### PR TITLE
Issue 21 protein ids

### DIFF
--- a/docs/basic_use.rst
+++ b/docs/basic_use.rst
@@ -128,4 +128,22 @@ does it preserve sequence gap symbols:
     GCTTTAGCACCTGGAGCTGAGGTAGTGCAA
 
 
+-----------------------------
+Use Protein IDs in the Output
+-----------------------------
+
+By default `ncfp` lists the nucleotide id retrieved from the nucleotide record in the final FASTA file 
+of nucleotide sequences (if the nucleotide id could not be retrieved the protein ID is used instead). 
+However, some applications require the protein sequence and associated CDS sequence to be identifiable 
+by sharing the same ID, for example when backthreading nucletide sequences onto alignmened protein 
+sequnces using `t-coffee`.
+
+To use the protein IDs for the IDs of the nucleotide sequences use 
+the `--use_protein_ids` flag.
+
+.. code-block:: bash
+
+    ncfp <INPUT>.fasta <OUTPUT> <EMAIL> --use_protein_ids
+
+
 .. [#f1] The user's email address is passed to NCBI to enable them to monitor use of their service and provide support

--- a/ncbi_cds_from_protein/scripts/ncfp.py
+++ b/ncbi_cds_from_protein/scripts/ncfp.py
@@ -151,7 +151,7 @@ def extract_cds_features(seqrecords, cachepath: Path, args: Namespace):
                     stockholm = [int(e) for e in locdata.split("-")]
                 else:
                     stockholm = []
-                ntseq, aaseq = extract_feature_cds(feature, gbrecord, stockholm)
+                ntseq, aaseq = extract_feature_cds(feature, gbrecord, stockholm, args)
                 if aaseq.seq == record.seq.ungap("-").upper():
                     logger.info("\t\tTranslated sequence matches input sequence")
                     nt_sequences.append((record, ntseq))

--- a/ncbi_cds_from_protein/scripts/parsers.py
+++ b/ncbi_cds_from_protein/scripts/parsers.py
@@ -151,6 +151,16 @@ def parse_cmdline(args=None):
         help="filename for skipped sequences",
     )
     parser.add_argument(
+        "--use_protein_ids",
+        dest="use_protein_ids",
+        action="store_true",
+        default=False,
+        help=(
+            "Use protein IDs not nucleotide IDs in the nucleotide sequence output\n"
+            "(e.g. for use in backthreading)"
+        ),
+    )
+    parser.add_argument(
         "-l",
         "--logfile",
         dest="logfile",

--- a/ncbi_cds_from_protein/sequences.py
+++ b/ncbi_cds_from_protein/sequences.py
@@ -195,12 +195,13 @@ def extract_feature_by_protein_id(record, tag, ftype="CDS"):
 
 
 # Extract the coding sequence from a feature
-def extract_feature_cds(feature, record, stockholm):
+def extract_feature_cds(feature, record, stockholm, args):
     """Returns SeqRecord with CDS and translation of GenBank record feature.
 
-    feature      - SeqFeature object
-    record       - SeqRecord object
-    stockholm    - List of (start, end) aa positions
+    :param feature:  SeqFeature object
+    :param record:  SeqRecord object
+    :param stockholm:  List of (start, end) aa positions
+    :param args:  CLI script arguments
     """
     # Extract nucleotide coding sequence
     ntseq = feature.extract(record.seq)
@@ -223,27 +224,27 @@ def extract_feature_cds(feature, record, stockholm):
         aaseq = aaseq[:-1]
 
     # Create SeqRecords of CDS and conceptual translation
-    if "locus_tag" in feature.qualifiers:
+    if (args.use_protein_ids) or ("locus_tag" not in feature.qualifiers):
         ntrecord = SeqRecord(
             seq=ntseq,
             description="coding sequence",
-            id=feature.qualifiers["locus_tag"][0],
+            id=feature.qualifiers["protein_id"][0],
         )
         aarecord = SeqRecord(
             seq=aaseq,
             description="conceptual translation",
-            id=feature.qualifiers["locus_tag"][0],
+            id=feature.qualifiers["protein_id"][0],
         )
     else:
         ntrecord = SeqRecord(
             seq=ntseq,
             description="coding sequence",
-            id=feature.qualifiers["protein_id"][0],
+            id=feature.qualifiers["locus_tag"][0],
         )
         aarecord = SeqRecord(
             seq=aaseq,
             description="conceptual translation",
-            id=feature.qualifiers["protein_id"][0],
+            id=feature.qualifiers["locus_tag"][0],
         )
 
     return ntrecord, aarecord

--- a/tests/test_ncfp.py
+++ b/tests/test_ncfp.py
@@ -119,6 +119,7 @@ def namespace_base(email_address, path_ncbi, tmp_path):
         filestem="ncfp",
         keepcache=False,
         skippedfname="skipped.fasta",
+        use_protein_ids=False,
         logfile=None,
         verbose=False,
         disabletqdm=True,


### PR DESCRIPTION
Addresses issues #21 

Adds the option to use protein IDs in the final FASTA file containing nucleotide sequences, to remove the need for additional parsing of the nucleotide sequence FASTA file to make it compatable with sequence backthreading tools suc has `t-coffee`.

## Changes
- Adds the `--use_protein_ids` flag (BOOL, default False)
- Updates docs (adds description of the `--use_protein_ids` flag to the 'Basic Usage' page)
- Update unit tests (adds `--use_protein_ids` to `namespace_base` to `pytest` `fixture`)

All unit tests passed locally.