### PR TITLE
fixes issue #27

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: black
       language_version: python3
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.10.0
+    rev: v1.12.1
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## v0.2.1a1
 
 - fix badges (Zenodo/PyPI) in `README.md`
+- make Stockholm domains work with NCBI sequence inputs (#27)
+- update requirements to avoid deprecated `requests-cache` (#26)
 
 ## v0.2.0
 

--- a/ncbi_cds_from_protein/scripts/ncfp.py
+++ b/ncbi_cds_from_protein/scripts/ncfp.py
@@ -69,6 +69,7 @@ from ncbi_cds_from_protein.sequences import (
     extract_feature_by_locus_tag,
     extract_feature_by_protein_id,
     extract_feature_cds,
+    strip_stockholm_from_seqid
 )
 
 
@@ -135,8 +136,9 @@ def extract_cds_features(seqrecords, cachepath: Path, args: Namespace):
                 logger.info("Searching for CDS: %s", gene_name)
                 feature = extract_feature_by_locus_tag(gbrecord, gene_name)
             else:  # NCBI sequences
-                # Get the matching CDS
-                feature = extract_feature_by_protein_id(gbrecord, record.id)
+                # Get the matching CDS - note we have to remove the Stockholm
+                # domain info, if that is present
+                feature = extract_feature_by_protein_id(gbrecord, strip_stockholm_from_seqid(record.id))
             if feature is None:
                 logger.info("Could not identify CDS feature for %s", record.id)
             else:

--- a/ncbi_cds_from_protein/sequences.py
+++ b/ncbi_cds_from_protein/sequences.py
@@ -247,3 +247,10 @@ def extract_feature_cds(feature, record, stockholm):
         )
 
     return ntrecord, aarecord
+
+def strip_stockholm_from_seqid(seqid):
+    """Strip Stockholm header from seqid.
+
+    seqid        - seqid to strip
+    """
+    return seqid.split("/")[0]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 bandit
 black
+blacken-docs
 flake8
 graphviz
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 biopython
 bioservices
+requests-cache >= 0.6
 tqdm


### PR DESCRIPTION
This commit adds a function to strip Stockholm domains from NCBI
file FASTA seqIDs - `-s` should now work with NCBI format inputs.