### PR TITLE
log warning, but don't raise error, when record is missing/suppressed

### DIFF
--- a/ncbi_cds_from_protein/entrez.py
+++ b/ncbi_cds_from_protein/entrez.py
@@ -253,7 +253,12 @@ def search_nt_ids(records, cachepath, retries, disabletqdm=True):
                 idlist = [lid["Id"] for lid in result[0]["LinkSetDb"][0]["Link"]]
                 logger.debug("result: %s, idlist: %s", result, idlist)
             except IndexError:  # No result returned - possible deleted record
-                raise NCFPEFetchException("No link/record returned for %s" % record.id)
+                logger.warning(
+                    "No result returned for %s: possible deleted record - please check",
+                    record.id,
+                )
+                # raise NCFPEFetchException("No link/record returned for %s" % record.id)
+                idlist = None
             if idlist:
                 addedrows.extend(add_ncbi_uids(cachepath, record.id, idlist))
                 logger.debug("record.id: %s, idlist: %s", record.id, idlist)

--- a/ncbi_cds_from_protein/sequences.py
+++ b/ncbi_cds_from_protein/sequences.py
@@ -128,6 +128,12 @@ def process_sequences(records, cachepath: Path, disabletqdm: bool = True):
             # to the returned field for the cross-reference to EMBL
             result = u_service.search(match.group(0), columns="xref_embl")  # type: ignore
             qstring = result.split("\n")[1].strip()[:-1]
+            if qstring == "":
+                logger.warning(
+                    "Uniprot record %s has no EMBL cross-reference (skipping)",
+                    record.id,
+                )
+                continue
             logger.debug("Recovered EMBL database record: %s", qstring)
             # UniProt can return multiple UIDs separated by semicolons. Sometimes the same
             # UID is repeated. However, the current cache schema uses the accession as primary


### PR DESCRIPTION
Rather than raising an error and halting when a suppressed or deleted input sequence is provided, skip instead.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as previously expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for eacxh)
- [ ] Fork the `ncfp` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (e.g. `make setup_env`)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest -v` **non-passing code will not be merged**
- [x] Rebase against `origin/master`
- [X] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/ncfp/pulls) in the `ncfp` repository
