### PR TITLE
fix issue with UniProt API query

### DIFF
--- a/ncbi_cds_from_protein/sequences.py
+++ b/ncbi_cds_from_protein/sequences.py
@@ -123,10 +123,19 @@ def process_sequences(records, cachepath: Path, disabletqdm: bool = True):
                 )
                 skipped.append(record)
                 continue
-            logger.debug("Uniprot record has GN field: %s", match.group(0))
+            logger.debug(
+                "Uniprot record %s has GN field: %s", record.id, match.group(0)
+            )
             # The UniProt API was updated in June 2022, requiring a change
             # to the returned field for the cross-reference to EMBL
-            result = u_service.search(match.group(0), columns="xref_embl")  # type: ignore
+            # Get the UniProt ID from the accession and use this to query the API
+            query_acc = record.id.split("|")[1]
+            logger.debug(
+                "Querying UniProt with %s to match xref_embl",
+                query_acc,
+            )
+            # Use the UniProt record ID as the query to the EMBL ID
+            result = u_service.search(query_acc, columns="xref_embl")  # type: ignore
             qstring = result.split("\n")[1].strip()[:-1]
             if qstring == "":
                 logger.warning(
@@ -202,6 +211,7 @@ def extract_feature_by_protein_id(record, tag, ftype="CDS"):
         except KeyError:
             continue
     return None
+
 
 # Extract a gene feature by gene_id
 def extract_feature_by_gene_id(record, tag, ftype="CDS"):


### PR DESCRIPTION
The old method of querying was not using the proper UniProt accession. That is fixed here by taking the string between two pipes to be the query term.

_Please include here a summary of the change and which issue is fixed. Please also include the motivation and context, and note the tests (state the file/test function, if possible) that apply to these changes._

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as previously expected)
- [ ] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [X] Fork the `ncfp` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (e.g. `make setup_env`)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest -v` **non-passing code will not be merged**
- [ ] Rebase against `origin/master`
- [X] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/ncfp/pulls) in the `ncfp` repository
