### PR TITLE
allow recovery of input sequences requiring GeneID

### DIFF
--- a/ncbi_cds_from_protein/entrez.py
+++ b/ncbi_cds_from_protein/entrez.py
@@ -277,6 +277,8 @@ def update_gb_accessions(cachepath, retries, disabletqdm=True):
     For each UID in nt_uid_acc where there is no GenBank accession,
     obtain the GenBank accession and update the row.
     """
+    logger = logging.getLogger(__name__)
+
     updatedrows = []
     noupdate = 0
     for uid in tqdm(
@@ -290,8 +292,10 @@ def update_gb_accessions(cachepath, retries, disabletqdm=True):
             .strip()
         )
         if result is None:
+            logger.debug("Could not update GenBank for %s", uid)
             noupdate += 1
         else:
+            logger.debug("Updating GenBank for %s as %s", uid, result)
             updatedrows.extend(update_nt_uid_acc(cachepath, uid, result))
     return updatedrows, noupdate
 
@@ -308,7 +312,7 @@ def esearch_with_retries(query_id, dbname, maxretries):
     after trying the ESearch up to a maximum number of times.
     """
     logger = logging.getLogger(__name__)
-    logger.debug("ESearch query: %s", query_id)
+    logger.debug("ESearch query: %s (db: %s)", query_id, dbname)
 
     tries = 0
     while tries < maxretries:


### PR DESCRIPTION
Some UniProt sequences link directly to an NCBI gene record, rather than a nucleotide record. This requires recovery of the xref_geneid and xref_refseq terms.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as previously expected)
- [X] This change requires a documentation update
- [ ] This is a documentation update

## Action Checklist

- [X] Work on a single issue/concept (if there are multiple separate issues to address, please use a separate pull request for each)
- [X] Fork the `ncfp` repository under your own account (please [allow write access for repository maintainers](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork))
- [X] Set up an appropriate development environment (e.g. `make setup_env`)
- [X] Create a new branch with a short, descriptive name
- [X] Work on this branch
  - [X] style guidelines have been followed
  - [X] new code is commented, especially in hard-to-understand areas
  - [ ] corresponding changes to documentation have been made
  - [ ] tests for the change have been added that demonstrate the fix or feature works
- [X] Test locally with `pytest -v` **non-passing code will not be merged**
- [ ] Rebase against `origin/master`
- [X] Check changes with `flake8` and `black` before submission
- [X] Commit branch
- [X] Submit pull request, describing the content and intent of the pull request
- [ ] Request a code review
- [ ] Continue the discussion at [`Pull requests` section](https://github.com/widdowquinn/ncfp/pulls) in the `ncfp` repository
